### PR TITLE
👷📝 Harden CI/publish and enrich AGENTS.md conventions

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/template/.github/workflows/ci.yml.jinja
+++ b/template/.github/workflows/ci.yml.jinja
@@ -6,10 +6,15 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  group: ci-{% raw %}${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Lint, type-check{% if use_pytest %}, test{% endif %} ({% raw %}${{ matrix.os }}{% endraw %})
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -25,7 +30,7 @@ jobs:
           enable-cache: true
 
       - name: Sync dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --locked
 
       - name: Ruff format check
         run: uv run ruff format --check .

--- a/template/.github/workflows/publish.yml.jinja
+++ b/template/.github/workflows/publish.yml.jinja
@@ -21,6 +21,15 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Verify tag matches project version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(uv version --short)"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag 'v$tag' does not match project version '$version'"
+            exit 1
+          fi
+
       - name: Build sdist and wheel
         run: uv build
 
@@ -53,6 +62,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           print-hash: true
           attestations: true
+          skip-existing: true
 {% endif %}
   pypi:
     name: Publish to PyPI
@@ -73,3 +83,36 @@ jobs:
         with:
           print-hash: true
           attestations: true
+
+  github-release:
+    name: Create GitHub release
+    needs: pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: distributions
+          path: dist/
+
+      - name: Extract release notes from CHANGELOG
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; next }
+            /^## / { if (flag) exit }
+            flag { print }
+          ' CHANGELOG.md > release-notes.md
+          cat release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: {% raw %}${{ github.token }}{% endraw %}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -44,6 +44,9 @@ branch tracking; the `fail_under` gate lives in `pyproject.toml`
 - Keep code fully typed — `ty` runs with `error-on-warning`.
 - Fix `ruff` findings rather than suppressing them, unless there is a
   clear, commented reason.
+- Error messages name the valid set or the fix, not just the failure
+  ("unsupported kind 'X': expected A, B, or C"; "... use `suspend()`") —
+  tell the caller what to do next.
 {%- if use_pytest %}
 - Tests live in `tests/` and may use bare `assert` (ruff `S101` is
   waived there).
@@ -54,6 +57,20 @@ branch tracking; the `fail_under` gate lives in `pyproject.toml`
   default, applies to `tests/` only. Use a root `conftest.py` only for
   `pytest_plugins` declarations, doctest fixtures shared with source
   files, or project-wide collection hooks.
+- Test layout: flat module-level `def test_*` functions by default; reach
+  for a plain `class TestX:` (grouping only, no inheritance) to organize a
+  large or multi-feature surface, and don't mix the two within one file.
+  Not every source file needs its own test file — types-only modules,
+  re-export `__init__.py` markers, and details covered through a public
+  module are intentional exceptions. Importable test helpers live in
+  `tests/<pkg>/helpers.py` (or `tests/fixtures/` for larger shared ones),
+  distinct from `conftest.py`'s auto-discovered fixtures.
+- Test quality: assertions check concrete return values **and** side
+  effects, not merely "no exception raised"; error paths use
+  `pytest.raises(..., match=...)`; verify numbers against independently
+  computed values (not the implementation's own output); make timing / IO
+  deterministic (an injected clock, fault injection) rather than flaky — a
+  good test fails on *subtle* breakage, not just obvious breakage.
 {%- endif %}
 - `ty` has no plugin system; rely on standard typing (PEP 681
   `dataclass_transform`, `.pyi` stubs), not type-checker plugins.
@@ -76,23 +93,45 @@ applying it by hand.
   party, then a trailing `if TYPE_CHECKING:` block (grouped the same
   way). Within a group `import X` precedes `from X import Y`; entries are
   alphabetical.
+- Within a function body, separate logical groups with a single blank line
+  and put a blank line before the final `return`; leave a tightly coupled
+  one- or two-line body unbroken.
+- In a long module, group related definitions under a boxed comment banner —
+  a centred title between two `#`-bordered rules.
 - Docstrings are optional — write them where they clarify intent, not
-  mechanically on every function, class, or method. When written,
-  document *intent and contracts, not mechanism*:
-  - Lead with a one-line summary — a declarative noun phrase for
-    classes ("An ordered, read-only view over ..."), an imperative
-    verb phrase for functions and methods ("Yield successive windows
-    from `items`.").
-  - Surface what callers cannot infer from the signature alone:
-    invariants, edge cases, what subclasses must override, policy
-    trade-offs. Skip restating what the code already shows.
+  mechanically on every function, class, or method. "Mechanically" targets
+  two habits to avoid: comments (or docstrings) that merely restate the
+  code, and a base class whose docstring explains itself in terms of its
+  specific subclasses — except a *closed* hierarchy's base, which may name
+  its subclasses as a deliberate family map. It is *not* a licence to leave
+  a consumed method bare. When written, document *intent and contracts, not
+  mechanism*:
+  - Lead with a one-line summary — a declarative noun phrase for classes
+    ("An ordered, read-only view over ..."), an imperative verb phrase for
+    functions and methods ("Yield successive windows from `items`."). Two
+    kinds take a noun phrase instead: a property getter ("The reporting
+    unit ...") and a boolean-returning *method*, which leads with
+    "Whether ..." ("Whether `path` exists."). A boolean *function* stays
+    imperative ("Test whether a path exists.").
+  - A concrete public method a caller consumes must be self-explainable from
+    its own docstring and signature — never lean on an inherited parent
+    docstring. Abstract base methods document only the generic contract and
+    never name a specific subclass.
+  - Surface what callers cannot infer from the signature alone: invariants,
+    edge cases, what subclasses must override, policy trade-offs. Skip
+    restating what the code already shows.
   - Use [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
     sections (`Args:`, `Returns:`, `Yields:`, `Raises:`,
     `Type Parameters:`); omit types from `Args:` since the signature
-    already carries them. Custom sections (`Example:`, and ad-hoc
-    labels) are welcome when they clarify a real pitfall or pattern.
+    already carries them. Custom sections (`Example:`, `Truth table:`, and
+    ad-hoc labels) are welcome when they clarify a real pitfall or pattern.
+  - Add an `Args:` / `Returns:` block only for what the summary and signature
+    cannot already convey. When they make the behaviour obvious (a no-arg
+    getter, a self-evident one-liner), the summary *is* the whole docstring;
+    a `Returns:` that merely restates it is the mechanical habit above.
   - Reference identifiers in backticks (`my_method`, `param`,
-    `MyClass.method`).
+    `MyClass.method`). Literal option values get backticks too
+    (`"merge"`, `"error"`), as identifiers do.
 - Standalone runnable scripts carry PEP 723 inline metadata (the
   `# /// script` block). `uv` manages it (`uv add --script`); add or edit
   it by hand only when explicitly asked.
@@ -128,6 +167,7 @@ Common prefixes used in this project:
 | 🚚     | Move / rename files                           |
 | ⬆️     | Bump a dependency or tool version             |
 | 🔧     | Config (`pyproject.toml`, `ruff`, `ty`, ...)  |
+| 👷     | CI workflow (`ci.yml`, `publish.yml`)         |
 | 🔖     | Release a version (commit + matching tag)     |
 
 Keep commits single-purpose; don't rewrite published history; don't
@@ -154,12 +194,14 @@ Releases publish automatically via GitHub Actions **Trusted Publishing**
    `git tag -a vX.Y.Z -m "🔖 Release version X.Y.Z" && git push origin vX.Y.Z`.
 
 The `v*.*.*` tag triggers `.github/workflows/publish.yml`: it reruns
-CI across the OS matrix, builds the distributions once and uploads
-them as an artifact,{% if use_testpypi %} publishes them to TestPyPI as a staging
+CI across the OS matrix, builds the distributions once (after asserting
+the tag matches `pyproject.toml`'s `version`) and uploads them as an
+artifact,{% if use_testpypi %} publishes them to TestPyPI as a staging
 rehearsal,{% endif %} then — once you approve the `pypi` environment gate —
-publishes the same artifacts to PyPI via OIDC. Keeping `build`
-separate from publish keeps the `id-token: write` permission scoped
-to the publish jobs only.
+publishes the same artifacts to PyPI via OIDC and creates the matching
+GitHub Release (the `CHANGELOG.md` section as the notes, sdist + wheel
+attached). Keeping `build` separate from publish keeps the
+`id-token: write` permission scoped to the publish jobs only.
 
 ### One-time setup (before the first release)
 


### PR DESCRIPTION
Folds back generic improvements that accrued in a generated project
(`kaparoo-python`, currently template `v1.0.2`) but never returned to the
template, so new projects start with them.

## 👷 CI & publish (`ci.yml.jinja`, `publish.yml.jinja`, `dependabot.yml`)
- **ci**: `concurrency` group (cancel superseded runs), `timeout-minutes`, and
  `uv sync --locked` (a stale `uv.lock` now fails CI).
- **publish**: assert the pushed tag matches `pyproject.toml`'s `version`
  before building; `skip-existing` on the TestPyPI upload; a new
  **`github-release`** job that, after the PyPI publish, creates the GitHub
  Release for the tag — `CHANGELOG.md` section as the notes, sdist + wheel
  attached.
- **dependabot**: weekly `github-actions` updates for the pinned actions.

## 📝 AGENTS.md conventions (`AGENTS.md.jinja`)
- **Docstrings**: two-habits-to-avoid + closed-hierarchy family-map carve-out;
  concrete-method-self-explainable / abstract-base-stays-generic; noun-phrase
  summaries for property getters and boolean *methods* ("Whether ...") vs
  imperative boolean *functions* ("Test whether ..."); `Args:`/`Returns:` only
  when they add information; backtick literal option values.
- **Tests**: flat-functions-vs-classes, the "not every file needs a test"
  exceptions, `helpers.py`/`fixtures/`, plus a test-*quality* note.
- **Style**: blank-line grouping + boxed banners; actionable error messages.
- Add the `👷` gitmoji row; document the publish tag/version check + the
  GitHub Release.

## Validation
Generated projects from this branch (`copier copy --vcs-ref HEAD`) in two
shapes and confirmed:
- `github-oidc` + TestPyPI → `publish.yml` jobs `[ci, build, testpypi, pypi,
  github-release]`, valid YAML, all additions present.
- `github-oidc`, no TestPyPI → `[ci, build, pypi, github-release]`, `pypi`
  needs `build`, `skip-existing` correctly absent. Conditional jinja branches
  intact.

## After merge
Tag a new template release (e.g. `v1.1.0`); existing projects pick this up via
`copier update`.